### PR TITLE
Use checked-in parser for prebuild

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "build": "LBUG_IN_MEMORY=true LBUG_WASM=false NODE_ENV=production vue-cli-service build",
     "lint": "vue-cli-service lint",
     "fetch-datasets": "node src/server/utils/FetchDatasets.js",
-    "generate-grammar-prod": "python3 ladybug/scripts/antlr4/keywordhandler.py ladybug/src/antlr4/Cypher.g4 ladybug/src/antlr4/keywords.txt ./Cypher.g4 /tmp/header.h && rm /tmp/header.h && rm -rf src/utils/CypherParser/ && npx antlr4ng-cli -o src/utils/CypherParser -Dlanguage=TypeScript -no-visitor -no-listener Cypher.g4 && rm Cypher.g4 && cd src/utils/CypherParser && mv CypherParser.ts CypherParserOld.ts && grep -v \"notify\" CypherParserOld.ts > CypherParser.ts && rm CypherParserOld.ts",
+    "generate-grammar-prod": "node -e \"require('fs').accessSync('src/utils/CypherParser/CypherParser.ts'); console.log('Using checked-in Cypher parser')\"",
     "generate-grammar": "python3 ladybug/scripts/antlr4/keywordhandler.py ladybug/src/antlr4/Cypher.g4 ladybug/src/antlr4/keywords.txt ./Cypher.g4 /tmp/header.h && rm /tmp/header.h && rm -rf src/utils/CypherParser/ && npx antlr4ng-cli -o src/utils/CypherParser -Dlanguage=TypeScript -no-visitor -no-listener Cypher.g4 && rm Cypher.g4 && cd src/utils/CypherParser && mv CypherParser.ts CypherParserOld.ts && grep -v \"notify\" CypherParserOld.ts > CypherParser.ts && rm CypherParserOld.ts",
     "clean": "rm -rf node_modules dist datasets src/utils/CypherParser",
     "eslint": "eslint --ext .js,.vue src",


### PR DESCRIPTION
## Summary
- make `generate-grammar-prod` use the checked-in Cypher parser instead of the removed `ladybug` submodule
- keep manual grammar regeneration on `npm run generate-grammar`, as documented in the README

## Why
The prebuild workflow failed after the submodule removal because `generate-grammar-prod` still tried to run `ladybug/scripts/antlr4/keywordhandler.py`. CI only needs a parser present for production packaging, and the generated parser is checked into `src/utils/CypherParser`.

## Validation
- `npm run generate-grammar-prod`
