### PR TITLE
Update Ladybug packages to 0.18.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,8 +11,8 @@
       "dependencies": {
         "@antv/g6": "^5.0.49",
         "@duckdb/duckdb-wasm": "1.29.0",
-        "@ladybugdb/core": "0.17.0",
-        "@ladybugdb/wasm-core": "0.17.0",
+        "@ladybugdb/core": "0.18.0",
+        "@ladybugdb/wasm-core": "0.18.0",
         "antlr4-c3": "3.2.3",
         "antlr4ng": "1.0.7",
         "bootstrap": "^5.3.1",
@@ -2356,9 +2356,9 @@
       }
     },
     "node_modules/@ladybugdb/core": {
-      "version": "0.17.0",
-      "resolved": "https://registry.npmjs.org/@ladybugdb/core/-/core-0.17.0.tgz",
-      "integrity": "sha512-fg7EGEJUj6H5JJLpU3iD5R0pAEc9u2OkU7ufX10krph9bCIhQyt/Tk6y/g4+x9zi/IHXegOjAVfSpWZp1gpoAA==",
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/@ladybugdb/core/-/core-0.18.0.tgz",
+      "integrity": "sha512-3X1NCsZZn2oPF/KtvrbQtRu9NvRw9z6BvNSW3lO9xe/I89HSnAsXXFaMDIirLnm3hgGb8ocnVhuMAyfS4DXnhA==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -2367,17 +2367,17 @@
         "node-addon-api": "^6.0.0"
       },
       "optionalDependencies": {
-        "@ladybugdb/core-darwin-arm64": "0.17.0",
-        "@ladybugdb/core-darwin-x64": "0.17.0",
-        "@ladybugdb/core-linux-arm64": "0.17.0",
-        "@ladybugdb/core-linux-x64": "0.17.0",
-        "@ladybugdb/core-win32-x64": "0.17.0"
+        "@ladybugdb/core-darwin-arm64": "0.18.0",
+        "@ladybugdb/core-darwin-x64": "0.18.0",
+        "@ladybugdb/core-linux-arm64": "0.18.0",
+        "@ladybugdb/core-linux-x64": "0.18.0",
+        "@ladybugdb/core-win32-x64": "0.18.0"
       }
     },
     "node_modules/@ladybugdb/core-darwin-arm64": {
-      "version": "0.17.0",
-      "resolved": "https://registry.npmjs.org/@ladybugdb/core-darwin-arm64/-/core-darwin-arm64-0.17.0.tgz",
-      "integrity": "sha512-wghUBEmcQ9U10QOyOxXVQTZ6SHtkB8QV3sJHwCj2Dn5B/SsaB36kA4l2oKbgXpKDgjmSYiz3DfMs5yfDqen9UA==",
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/@ladybugdb/core-darwin-arm64/-/core-darwin-arm64-0.18.0.tgz",
+      "integrity": "sha512-HlJswkjSdPyXDp+krZBnU5jHQYK/1G4jTBj9Y5cUkm7ze+qR7mj9bkstUldEC3t2N7W6Os7wzTIUUORpHDRGvA==",
       "cpu": [
         "arm64"
       ],
@@ -2388,9 +2388,9 @@
       ]
     },
     "node_modules/@ladybugdb/core-darwin-x64": {
-      "version": "0.17.0",
-      "resolved": "https://registry.npmjs.org/@ladybugdb/core-darwin-x64/-/core-darwin-x64-0.17.0.tgz",
-      "integrity": "sha512-f0QRhmDY8NEMjAT3IbFELMEFxAnKq6trppn1vgAFIk9wTD/MKakfX/gtXOazpOZQHkwlfNgs+WSkJFfFvQ4JaQ==",
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/@ladybugdb/core-darwin-x64/-/core-darwin-x64-0.18.0.tgz",
+      "integrity": "sha512-NUqnxnnGPs3XR86/4fLWsn+Cz9/sykVIaNOw3BsYccpiGWKvnGnDcpKID1HVHRcSa84N+CrXPkuzUvkRD36s3Q==",
       "cpu": [
         "x64"
       ],
@@ -2401,9 +2401,9 @@
       ]
     },
     "node_modules/@ladybugdb/core-linux-arm64": {
-      "version": "0.17.0",
-      "resolved": "https://registry.npmjs.org/@ladybugdb/core-linux-arm64/-/core-linux-arm64-0.17.0.tgz",
-      "integrity": "sha512-TS9nbkvLJZt3Tgm6zzd/QuZmTiVoyQTPfbbwPej0VfcCVAfa1sDpZtoMlwse9EVHOrowQ0SorJVPg194lYVxdg==",
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/@ladybugdb/core-linux-arm64/-/core-linux-arm64-0.18.0.tgz",
+      "integrity": "sha512-/wHoqsPOna+lZZbeAOFRiTHHpaiuA+07H5FUQqZI/qrEfjjN38xznmnLVCE5YZcFCzNxAS4aK40rXaUFZLj+Ow==",
       "cpu": [
         "arm64"
       ],
@@ -2414,9 +2414,9 @@
       ]
     },
     "node_modules/@ladybugdb/core-linux-x64": {
-      "version": "0.17.0",
-      "resolved": "https://registry.npmjs.org/@ladybugdb/core-linux-x64/-/core-linux-x64-0.17.0.tgz",
-      "integrity": "sha512-T/C0QKDoBCs8s/NQ2Udip8lZgJ8MzLqs2rRgreDd2dCP3aNnXu8eOBe10RSoRO5PiZZIZihXoz4Q8KMM6FtBGQ==",
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/@ladybugdb/core-linux-x64/-/core-linux-x64-0.18.0.tgz",
+      "integrity": "sha512-ge9pGnU94jVBOYxAuUq3d9BYSS3ProtwIKse9ZKXxeL9Hh8Qmwcz9Ey++BJMm+lSN8dE0lUBQTGXCTd1jrMnpA==",
       "cpu": [
         "x64"
       ],
@@ -2427,9 +2427,9 @@
       ]
     },
     "node_modules/@ladybugdb/core-win32-x64": {
-      "version": "0.17.0",
-      "resolved": "https://registry.npmjs.org/@ladybugdb/core-win32-x64/-/core-win32-x64-0.17.0.tgz",
-      "integrity": "sha512-XrQrbPD3h+MhP94jVu+4VgNnp8LKSskPll+/au+Ug3yqpXZ0We9lXX5+rW4NHuIYdAYy4iLheYz4OuozUS20qg==",
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/@ladybugdb/core-win32-x64/-/core-win32-x64-0.18.0.tgz",
+      "integrity": "sha512-RLW9m9BJ4LdFjKsTOZdg43FjmdboZ1gvhmnP494JPfVsmNt+7lMJOmhtvuePj3uAhOEd9qOpGN8hqGiPDywbOA==",
       "cpu": [
         "x64"
       ],
@@ -2653,9 +2653,9 @@
       }
     },
     "node_modules/@ladybugdb/wasm-core": {
-      "version": "0.17.0",
-      "resolved": "https://registry.npmjs.org/@ladybugdb/wasm-core/-/wasm-core-0.17.0.tgz",
-      "integrity": "sha512-KixXwTrqeTptxd90UHv9pRaCu81/QeajhT1EPiV6pOuSFlWS0ntOwwVO5M39URcvuyGvSgL0MpBE4Tm4PdQVnw==",
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/@ladybugdb/wasm-core/-/wasm-core-0.18.0.tgz",
+      "integrity": "sha512-56WB0J2meOW5nadrhQ4byHBm67iihdpE8lVe2epfF7+N5qtQ6NrU40yHpK7dyy2OlSp+rBAPhqIkJsx2rIecAA==",
       "license": "MIT",
       "dependencies": {
         "threads": "^1.7.0",

--- a/package.json
+++ b/package.json
@@ -21,8 +21,8 @@
   "dependencies": {
     "@antv/g6": "^5.0.49",
     "@duckdb/duckdb-wasm": "1.29.0",
-    "@ladybugdb/core": "0.17.0",
-    "@ladybugdb/wasm-core": "0.17.0",
+    "@ladybugdb/core": "0.18.0",
+    "@ladybugdb/wasm-core": "0.18.0",
     "antlr4-c3": "3.2.3",
     "antlr4ng": "1.0.7",
     "bootstrap": "^5.3.1",


### PR DESCRIPTION
Fixes: #33 

Bumps `@ladybugdb/core` and `@ladybugdb/wasm-core` from 0.17.0 to 0.18.0.